### PR TITLE
feat: Add 2-channel (White + Blue) LED support for older HeliaLux bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,14 @@ Download this repo and copy the `custom_components/juwel_helialux` folder to you
 
 ### Setup
 
-Once Home Assistant is back up, go to **Settings → Integrations** and add **Juwel HeliaLux**. Fill out the information (you'll need to know the host/IP of your controller). The integration will automatically detect whether your controller is a 2-channel (White + Blue) or 4-channel (RGB + White) model. Your sensors and light should (hopefully) appear.
+Once Home Assistant is back up, go to **Settings → Integrations** and add **Juwel HeliaLux**. Fill out the information (you'll need to know the host/IP of your controller) and select the correct **LED Channels** option for your hardware:
+
+* **4 Channels (RGBW)** — for standard HeliaLux Spectrum controllers with Red, Green, Blue and White channels. This is the default and matches the original integration behaviour.
+* **2 Channels (White + Blue)** — for older HeliaLux LED bars (e.g. HeliaLux LED 600/800 first generation) that only have White and Blue channels. This creates two separate brightness sliders (`light.tankname_light_white` and `light.tankname_light_blue`) instead of a colour wheel.
+
+> The channel mode can also be changed later via **Settings → Integrations → Juwel HeliaLux → Configure**.
+
+Your sensors and light should (hopefully) appear.
 
 ## Once installed
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,39 @@
-
-# Juwel HeliaLux Smart Controller
+# Juwel HeliaLux Smart Controller + 2-Channel Support
 
 This is a custom component for [Home Assistant](https://www.home-assistant.io/) that creates sensors to show details about your [Juwel HeliaLux Smart Controller](https://www.juwel-aquarium.co.uk/Products/Lighting/LED/HeliaLux-LED/HeliaLux-SmartControl/). It is *(heavily)* based on [pyHelialux](https://github.com/moretea/pyHelialux) by [moretea](https://github.com/moretea), but has been adapted to play nicer with Home Assistant (tested against 2026.2).
+
+> **This fork extends the original integration with support for 2-channel (White + Blue) HeliaLux controllers**, such as the HeliaLux Spectrum White & Blue models. If your controller only has White and Blue channels (no RGB), this is the version you need.
+>
+> A pull request to merge this 2-channel support into the [original repository](https://github.com/MrSleeps/Juwel-HeliaLux-Home-Assistant-Custom-Component) has been submitted — until it is merged, use this fork for 2-channel support.
 
 Once installed it gives you a bunch of sensors and a new light that you can turn on and off.
 
 ## Helialux firmware
-**Your controller needs to have the latest v2.2.2 firmware from Juwel for this custom component to work**
+
+**Your controller needs to have the latest v2.2.2 firmware from Juwel for this custom component to work.**
+
+## Supported controller types
+
+| Controller type | Channels | Supported |
+|---|---|---|
+| HeliaLux Spectrum (RGB + White) | Red, Green, Blue, White | ✅ Original + this fork |
+| HeliaLux Spectrum White & Blue | White, Blue | ✅ This fork only |
 
 ## Available sensors
 
-These sensors are read only, if you want to do things like turn the aquarium light on and off you will need to intereact with light.tank_name.
+These sensors are read only. If you want to do things like turn the aquarium light on and off you will need to interact with `light.tank_name`.
 
+**RGB + White controllers:**
 * `tankname_blue` (Blue light intensity, 0-100)
 * `tankname_green` (Green light intensity, 0-100)
 * `tankname_red` (Red light intensity, 0-100)
 * `tankname_white` (White light intensity, 0-100)
+
+**White + Blue controllers (2-channel):**
+* `tankname_white` (White light intensity, 0-100)
+* `tankname_blue` (Blue light intensity, 0-100)
+
+**All controller types:**
 * `tankname_current_profile` (Currently selected profile)
 * `tankname_profiles` (Count of available profiles)
 * `tankname_manualcolorsimulationenabled` **This will be removed in a future version**
@@ -24,6 +42,7 @@ These sensors are read only, if you want to do things like turn the aquarium lig
 * `tankname_tank_combined_sensor` (this combines all the above sensors into one)
 
 ## Other Entities/Devices
+
 * `number.tank_name_manual_color_simulation_duration` (Sets the amount of time manual simulation stays on for)
 * `binary_sensor.tank_name_manual_color_simulation` (On or off)
 * `switch.tank_name_manual_color_simulation` (Turns on or off Manual Colour Simulation)
@@ -31,34 +50,50 @@ These sensors are read only, if you want to do things like turn the aquarium lig
 * `light.tankname_light` (The main light, allows you to control your tank light)
 * `Tank Device` (All sensors are linked to the relevant device)
 
-
 ## How to install
 
 **Before we head down the install route, if you are upgrading from the original rubbish version I wrote years back, please read the [upgrade guide](https://github.com/MrSleeps/Juwel-HeliaLux-Home-Assistant-Custom-Component/blob/main/UPGRADE.md).**
 
-Once you have done that...
+### Via HACS (recommended)
 
-You can either install it via Hacs (search for Juwel Helialux) or download this repo and copy it to your config/custom_components folder on your Home Assistant install.
+1. In HACS, go to the three-dot menu (⋮) → **Custom repositories**
+2. Add `https://github.com/Eitschman/Juwel-HeliaLux-Home-Assistant-Custom-Component` as an **Integration**
+3. Search for **"Juwel HeliaLux"** in HACS and click **Download**
+4. Restart Home Assistant
 
-Once you've done either of those, restart your Home Assistant. Once Home Assistant is back up, head over to Settings -> Integrations and add Juwel Helialux. Fill out the information (you'll need to know the host/ip). Your sensors and light should (hopefully) appear.
+> **Note:** If you have the original integration already installed via HACS, remove it first before installing this fork, as both use the same integration domain.
+
+### Manual installation
+
+Download this repo and copy the `custom_components/juwel_helialux` folder to your `config/custom_components/` directory, then restart Home Assistant.
+
+### Setup
+
+Once Home Assistant is back up, go to **Settings → Integrations** and add **Juwel HeliaLux**. Fill out the information (you'll need to know the host/IP of your controller). The integration will automatically detect whether your controller is a 2-channel (White + Blue) or 4-channel (RGB + White) model. Your sensors and light should (hopefully) appear.
 
 ## Once installed
 
-You'll have your sensors listed above and a new light (light.tankname_light) to play with. You can change how long the manual simulation lasts for by changing the number.tank_name_manual_color_simulation value.
+You'll have your sensors listed above and a new light (`light.tankname_light`) to play with. You can change how long the manual simulation lasts for by changing the `number.tank_name_manual_color_simulation` value.
 
 ## Things to be aware of
 
-The Juwel Helialux unit is a bit clunky and is easily overloaded (mine at least). So when you are changing colours it can get overloaded and not do what you want it to do. 
+The Juwel Helialux unit is a bit clunky and is easily overloaded (mine at least). So when you are changing colours it can get overloaded and not do what you want it to do.
 
 **The controller website will cancel out all your changes if you visit the website manually! This includes embedding the page in Home Assistant (any time the controller website is opened it will take control of the controller and do its own thing).**
 
-Also, Home Assistants way of dealing with colours on the colour wheel doesn't play overly well with the Juwel Helialux Controller. If you are having trouble getting just RGB colours then drag the white brightness down and have a wiggle with the colour wheel. I'm working to fix it but tbh, I don't really know what I am doing. Any other bugs then please post on GitHub.
+Also, Home Assistant's way of dealing with colours on the colour wheel doesn't play overly well with the Juwel Helialux Controller. If you are having trouble getting just RGB colours then drag the white brightness down and have a wiggle with the colour wheel. I'm working to fix it but tbh, I don't really know what I am doing. Any other bugs then please post on GitHub.
 
 ## Bug Reports
-Please follow the template when submitting a bug report, to help **logs will be required**. To turn on debug logging for the integration you will need to add something like the following to your configuration.yml
+
+Please follow the template when submitting a bug report — to help, **logs will be required**. To turn on debug logging for the integration you will need to add something like the following to your `configuration.yaml`:
+
+```yaml
+logger:
+  default: info
+  logs:
+    custom_components.juwel_helialux: debug
 ```
-    logger:
-      default: info
-      logs:
-        custom_components.juwel_helialux: debug
-```
+
+## Credits
+
+Original integration by [MrSleeps](https://github.com/MrSleeps/Juwel-HeliaLux-Home-Assistant-Custom-Component). 2-channel (White + Blue) support added by [Eitschman](https://github.com/Eitschman).

--- a/custom_components/juwel_helialux/config_flow.py
+++ b/custom_components/juwel_helialux/config_flow.py
@@ -3,7 +3,7 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 import logging
 
-from .const import DOMAIN, CONF_TANK_HOST, CONF_TANK_NAME, CONF_TANK_PROTOCOL, CONF_UPDATE_INTERVAL
+from .const import DOMAIN, CONF_TANK_HOST, CONF_TANK_NAME, CONF_TANK_PROTOCOL, CONF_UPDATE_INTERVAL, CONF_LED_CHANNELS, LED_CHANNELS_4, LED_CHANNELS_2
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +34,10 @@ class JuwelHelialuxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_TANK_HOST): str,
             vol.Required(CONF_TANK_NAME): str,
             vol.Required(CONF_UPDATE_INTERVAL, default=1): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            vol.Required(CONF_LED_CHANNELS, default=LED_CHANNELS_4): vol.In({
+                LED_CHANNELS_4: "4 Channels (RGBW)",
+                LED_CHANNELS_2: "2 Channels (White + Blue)",
+            }),
         })
 
         return self.async_show_form(
@@ -142,6 +146,10 @@ class JuwelHelialuxOptionsFlow(config_entries.OptionsFlow):
             vol.Required(CONF_TANK_HOST, default=self._config_entry.data.get(CONF_TANK_HOST)): str,
             vol.Required(CONF_TANK_NAME, default=self._config_entry.data.get(CONF_TANK_NAME)): str,
             vol.Optional(CONF_UPDATE_INTERVAL, default=self._config_entry.data.get(CONF_UPDATE_INTERVAL, 1)): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            vol.Required(CONF_LED_CHANNELS, default=self._config_entry.data.get(CONF_LED_CHANNELS, LED_CHANNELS_4)): vol.In({
+                LED_CHANNELS_4: "4 Channels (RGBW)",
+                LED_CHANNELS_2: "2 Channels (White + Blue)",
+            }),
         })
 
         return self.async_show_form(

--- a/custom_components/juwel_helialux/const.py
+++ b/custom_components/juwel_helialux/const.py
@@ -6,3 +6,8 @@ CONF_TANK_HOST = "tank_host"
 CONF_TANK_NAME = "tank_name"
 CONF_TANK_PROTOCOL = "tank_protocol"
 CONF_UPDATE_INTERVAL = "update_interval"
+CONF_LED_CHANNELS = "led_channels"
+
+# LED channel modes
+LED_CHANNELS_4 = "4ch_rgbw"
+LED_CHANNELS_2 = "2ch_wb"

--- a/custom_components/juwel_helialux/light.py
+++ b/custom_components/juwel_helialux/light.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
-from .const import DOMAIN, CONF_UPDATE_INTERVAL
+from .const import DOMAIN, CONF_UPDATE_INTERVAL, CONF_LED_CHANNELS, LED_CHANNELS_2
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,11 +32,26 @@ async def async_setup_entry(
     _LOGGER.debug("Coordinator initial data: %s", coordinator.data)
 
     tank_name = entry.title
-    async_add_entities([JuwelHelialuxLight(coordinator, tank_name)], True)
+    led_channels = entry.data.get(CONF_LED_CHANNELS, None)
 
+    # Determine mode: if led_channels is not set (legacy config), default to 4-channel RGBW
+    if led_channels == LED_CHANNELS_2:
+        _LOGGER.debug("Setting up 2-channel (White + Blue) light entities")
+        async_add_entities([
+            JuwelHelialuxWhiteLight(coordinator, tank_name),
+            JuwelHelialuxBlueLight(coordinator, tank_name),
+        ], True)
+    else:
+        _LOGGER.debug("Setting up 4-channel (RGBW) light entity")
+        async_add_entities([JuwelHelialuxLight(coordinator, tank_name)], True)
+
+
+# =============================================================================
+# 4-Channel RGBW Light (original behavior)
+# =============================================================================
 
 class JuwelHelialuxLight(CoordinatorEntity, LightEntity):
-    """Representation of a Juwel Helialux Light in Home Assistant."""
+    """Representation of a Juwel Helialux Light in RGBW mode."""
 
     def __init__(self, coordinator, tank_name):
         """Initialize the light entity."""
@@ -52,7 +67,7 @@ class JuwelHelialuxLight(CoordinatorEntity, LightEntity):
         self._attr_is_on = False
         self._attr_brightness = None
         self._attr_rgbw_color = (0, 0, 0, 0)
-        self._attr_device_info = coordinator.device_info  # CORRECT
+        self._attr_device_info = coordinator.device_info
 
 
     @property
@@ -188,3 +203,122 @@ class JuwelHelialuxLight(CoordinatorEntity, LightEntity):
         except Exception as e:
             _LOGGER.error("Error turning off light: %s", e)
             raise
+
+
+# =============================================================================
+# 2-Channel Mode: Separate White and Blue brightness-only lights
+# =============================================================================
+
+class _JuwelHelialuxChannelLight(CoordinatorEntity, LightEntity):
+    """Base class for a single-channel brightness-only Helialux light."""
+
+    def __init__(self, coordinator, tank_name, channel_key, translation_key, unique_suffix):
+        """Initialize a single-channel light entity."""
+        super().__init__(coordinator)
+        self._controller = coordinator.helialux
+        self._channel_key = channel_key  # "white" or "blue"
+        tank_slug = slugify(tank_name)
+        self._tank_slug = tank_slug
+        self._attr_unique_id = f"{tank_slug}_{unique_suffix}"
+        self.entity_id = f"light.{self._attr_unique_id}"
+        self._attr_has_entity_name = True
+        self._attr_translation_key = translation_key
+        self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+        self._attr_color_mode = ColorMode.BRIGHTNESS
+        self._attr_is_on = False
+        self._attr_brightness = 0
+        self._attr_device_info = coordinator.device_info
+
+    def _get_other_channel_value(self):
+        """Return the current 0-100 value of the OTHER channel (to preserve it when setting this one)."""
+        raise NotImplementedError
+
+    @property
+    def is_on(self):
+        """Return true if this channel is on."""
+        if not self.coordinator.data:
+            return False
+        return self.coordinator.data.get(self._channel_key, 0) > 0
+
+    @property
+    def brightness(self):
+        """Return brightness for this channel (0-255)."""
+        if not self.coordinator.data:
+            return 0
+        raw = self.coordinator.data.get(self._channel_key, 0)
+        return int(raw * 2.55)
+
+    async def _send_color(self, white_pct, blue_pct):
+        """Send color command to the controller. Green and Red are always 0."""
+        await self.coordinator.set_manual_override(True, 5)
+        try:
+            duration_entity = f"number.{self._tank_slug}_manual_color_simulation_duration"
+            duration_state = self.coordinator.hass.states.get(duration_entity)
+            duration_minutes = int(float(duration_state.state) * 60) if duration_state else 720
+
+            await self._controller.start_manual_color_simulation(duration_minutes)
+            # API signature: set_manual_color(white, blue, green, red)
+            await self._controller.set_manual_color(white_pct, blue_pct, 0, 0)
+
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.error("Error setting %s light: %s", self._channel_key, e)
+            await self.coordinator.set_manual_override(False)
+            raise
+
+    async def async_turn_off(self, **kwargs):
+        """Turn this channel off (set to 0) while preserving the other channel."""
+        _LOGGER.debug("Turning off %s channel", self._channel_key)
+        other_value = self._get_other_channel_value()
+        if self._channel_key == "white":
+            await self._send_color(0, other_value)
+        else:
+            await self._send_color(other_value, 0)
+        self._attr_is_on = False
+        self._attr_brightness = 0
+
+
+class JuwelHelialuxWhiteLight(_JuwelHelialuxChannelLight):
+    """White channel light entity."""
+
+    def __init__(self, coordinator, tank_name):
+        super().__init__(coordinator, tank_name, "white", "light_white", "light_white")
+
+    def _get_other_channel_value(self):
+        """Return current blue value (0-100)."""
+        if not self.coordinator.data:
+            return 0
+        return self.coordinator.data.get("blue", 0)
+
+    async def async_turn_on(self, **kwargs):
+        """Turn white channel on."""
+        brightness = kwargs.get("brightness", 255)
+        white_pct = min(100, max(0, brightness / 2.55))
+        blue_pct = self._get_other_channel_value()
+        _LOGGER.debug("Setting white to %d%%, preserving blue at %d%%", white_pct, blue_pct)
+        await self._send_color(white_pct, blue_pct)
+        self._attr_is_on = True
+        self._attr_brightness = brightness
+
+
+class JuwelHelialuxBlueLight(_JuwelHelialuxChannelLight):
+    """Blue channel light entity."""
+
+    def __init__(self, coordinator, tank_name):
+        super().__init__(coordinator, tank_name, "blue", "light_blue", "light_blue")
+
+    def _get_other_channel_value(self):
+        """Return current white value (0-100)."""
+        if not self.coordinator.data:
+            return 0
+        return self.coordinator.data.get("white", 0)
+
+    async def async_turn_on(self, **kwargs):
+        """Turn blue channel on."""
+        brightness = kwargs.get("brightness", 255)
+        blue_pct = min(100, max(0, brightness / 2.55))
+        white_pct = self._get_other_channel_value()
+        _LOGGER.debug("Setting blue to %d%%, preserving white at %d%%", blue_pct, white_pct)
+        await self._send_color(white_pct, blue_pct)
+        self._attr_is_on = True
+        self._attr_brightness = brightness

--- a/custom_components/juwel_helialux/translations/de.json
+++ b/custom_components/juwel_helialux/translations/de.json
@@ -8,7 +8,8 @@
           "tank_protocol": "http oder https",
           "tank_host": "Tank Host (IP-Adresse)",
           "tank_name": "Tankname",
-          "update_interval": "Aktualisierungsintervall (1-60 Minuten)"
+          "update_interval": "Aktualisierungsintervall (1-60 Minuten)",
+          "led_channels": "LED-Kanäle"
         }
       }
     },
@@ -30,7 +31,8 @@
           "tank_protocol": "http oder https",
           "tank_host": "Tank Host (IP-Adresse)",
           "tank_name": "Tankname",
-          "update_interval": "Aktualisierungsintervall (1-60 Minuten)"
+          "update_interval": "Aktualisierungsintervall (1-60 Minuten)",
+          "led_channels": "LED-Kanäle"
         }
       }
     }
@@ -73,6 +75,12 @@
     "light": {
       "light_name": {
         "name": "Licht"
+      },
+      "light_white": {
+        "name": "Weißes Licht"
+      },
+      "light_blue": {
+        "name": "Blaues Licht"
       }
     },
     "select": {

--- a/custom_components/juwel_helialux/translations/en.json
+++ b/custom_components/juwel_helialux/translations/en.json
@@ -8,7 +8,8 @@
           "tank_protocol": "http or https",
           "tank_host": "Tank Host (IP address)",
           "tank_name": "Tank Name",
-          "update_interval": "Update Interval (1-60 minutes)"
+          "update_interval": "Update Interval (1-60 minutes)",
+          "led_channels": "LED Channels"
         }
       }
     },
@@ -30,7 +31,8 @@
           "tank_protocol": "http or https",
           "tank_host": "Tank Host (IP address)",
           "tank_name": "Tank Name",
-          "update_interval": "Update Interval (1-60 minutes)"
+          "update_interval": "Update Interval (1-60 minutes)",
+          "led_channels": "LED Channels"
         }
       }
     }
@@ -73,6 +75,12 @@
     "light": {
       "light_name": {
         "name": "Light"
+      },
+      "light_white": {
+        "name": "White Light"
+      },
+      "light_blue": {
+        "name": "Blue Light"
       }
     },
     "select": {

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Juwel Helialux Smart Controller",
+  "name": "Juwel HeliaLux Smart Controller + 2-Channel Support",
   "country": "GB",
   "homeassistant": "2026.1.1"
 }


### PR DESCRIPTION
## What does this do?

Older HeliaLux LED bars (e.g. HeliaLux LED 600/800 first generation) only have 
white and blue channels — no red or green. With the current RGBW color mode, 
Home Assistant displays these as a green-ish color on the color wheel, which is 
confusing and doesn't match the actual hardware.

This PR adds a configurable "LED Channels" option to the integration setup and 
options flow, allowing users to choose between:

- **4 Channels (RGBW)** — existing behavior, completely unchanged
- **2 Channels (White + Blue)** — creates two separate brightness-only light 
  entities (`light.tankname_light_white` and `light.tankname_light_blue`) with 
  simple sliders instead of a color wheel

## Changes

- `const.py` — new `CONF_LED_CHANNELS` constant with two mode identifiers
- `config_flow.py` — channel selection in setup + options flow
- `light.py` — 2-channel mode with separate White/Blue `ColorMode.BRIGHTNESS` entities
- `translations/en.json`, `de.json` — updated translations

## Non-breaking

Existing installations default to 4-channel RGBW mode. The new option only 
takes effect when explicitly selected via the config or options flow.